### PR TITLE
fix(csv2json): work around console.log limits w/util.inspect

### DIFF
--- a/bin/utils/utils.js
+++ b/bin/utils/utils.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const path = require('path'),
+    util = require('util'),
     fs = require('fs'),
     converter = require('json-2-csv');
 
@@ -79,7 +80,7 @@ function processOutput(params) {
         return writeToFile(params.output, JSON.stringify(params.outputData, null, 4));
     }
     // Otherwise, no output was specified so just send it to stdout via the console
-    console.log(params.outputData); // eslint-disable-line no-console
+    console.log(util.inspect(params.output, { maxArrayLength: null })); // eslint-disable-line no-console
 }
 
 function constructKeysList(key, keys) {


### PR DESCRIPTION
Fixes #7 - backwards-compatible output, but the output is not valid JSON

console.log is limited to around 100, as an implementation-specific detail[1]
This fixes a problem where CLI csv2json operating on CSV with greater than 100
lines and no output specified resulted in 100 lines only, then `... and NN more items.`,
instead of the full output you so richly deserved

[1] - https://console.spec.whatwg.org/#printer - node v16 uses 100 as limit