### PR TITLE
fix(csv2json): work around console.log limits / print valid JSON

### DIFF
--- a/bin/utils/utils.js
+++ b/bin/utils/utils.js
@@ -78,8 +78,8 @@ function processOutput(params) {
         // Pretty print the output when converting from CSV to JSON
         return writeToFile(params.output, JSON.stringify(params.outputData, null, 4));
     }
-    // Otherwise, no output was specified so just send it to stdout via the console
-    console.log(params.outputData); // eslint-disable-line no-console
+    // Otherwise, no output specified, convert to valid JSON string, send to stdout via the console
+    console.log(JSON.stringify(params.outputData, null, 2)); // eslint-disable-line no-console
 }
 
 function constructKeysList(key, keys) {


### PR DESCRIPTION
Fixes #7 / Obsoletes #8 - this is the solution I prefer personally, and it's the patch I'm using locally

Might be a breaking change? Definitely changes output from prior versions.

console.log is limited to around 100, as an implementation-specific detail[1]
This fixes a problem where CLI csv2json operating on CSV with greater than 100
lines and no output specified resulted in 100 lines only, then `... and NN more items.`,
instead of the full output you so richly deserved

Additionally, the JSON emitted was not valid JSON. 
JSON.stringify fixes both problems at once

[1] - https://console.spec.whatwg.org/#printer - node v16 uses 100 as limit