### PR TITLE
Bug fixes & match json-2-csv version

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Arguments:
 Options:
   -V, --version                output the version number
   -o, --output [output]        Path of output file. If not provided, then stdout will be used
+  -t, --header-fields          Specify the fields names in place a header line in the CSV itself
+  -k, --keys [keys]            Keys of documents to convert to JSON
   -f, --field <delimiter>      Field delimiter
   -w, --wrap <delimiter>       Wrap delimiter
   -e, --eol <delimiter>        End of Line delimiter
@@ -65,9 +67,7 @@ Options:
   -p, --prevent-csv-injection  Prevent CSV Injection
   -F, --trim-fields            Trim field values
   -H, --trim-header            Trim header fields
-  -h, --header-fields          Specify the fields names in place a header line in the CSV itself
-  -k, --keys [keys]            Keys of documents to convert to CSV
-  --help                       display help for command
+  -h, --help                   display help for command
 ```
 
 ### Memory

--- a/bin/csv2json.js
+++ b/bin/csv2json.js
@@ -11,6 +11,8 @@ program
     .usage('<csvFile> [options]')
     .argument('<csvFile>', 'CSV file to convert')
     .option('-o, --output [output]', 'Path of output file. If not provided, then stdout will be used', utils.convertToAbsolutePath)
+    .option('-t, --header-fields', 'Specify the fields names in place a header line in the CSV itself', utils.constructKeysList)
+    .option('-k, --keys [keys]', 'Keys of documents to convert to JSON', utils.constructKeysList)
     .option('-f, --field <delimiter>', 'Field delimiter')
     .option('-w, --wrap <delimiter>', 'Wrap delimiter')
     .option('-e, --eol <delimiter>', 'End of Line delimiter')
@@ -18,8 +20,6 @@ program
     .option('-p, --prevent-csv-injection', 'Prevent CSV Injection')
     .option('-F, --trim-fields', 'Trim field values')
     .option('-H, --trim-header', 'Trim header fields')
-    .option('-h, --header-fields', 'Specify the fields names in place a header line in the CSV itself', utils.constructKeysList)
-    .option('-k, --keys [keys]', 'Keys of documents to convert to CSV', utils.constructKeysList)
     .parse(process.argv);
 
 const options = program.opts();

--- a/bin/utils/utils.js
+++ b/bin/utils/utils.js
@@ -81,9 +81,10 @@ function processOutput(params) {
     } else { // CSV
         console.log(params.outputData);
     }
-    
+
 }
 
 function constructKeysList(keys) {
+    if (!Array.isArray(keys)) return keys;
     return keys.split(',');
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "license": "MIT",
             "dependencies": {
                 "commander": "12.1.0",
-                "json-2-csv": "5.5.5"
+                "json-2-csv": "5.5.6"
             },
             "bin": {
                 "csv2json": "bin/csv2json.js",
@@ -45,9 +45,9 @@
             }
         },
         "node_modules/json-2-csv": {
-            "version": "5.5.5",
-            "resolved": "https://registry.npmjs.org/json-2-csv/-/json-2-csv-5.5.5.tgz",
-            "integrity": "sha512-xLeiOE+jtDMX4SMn9JlD6BVI9c5SYVFmtlsNBSelGlq9iUHdVmwlxQ/uUI/BEVQuKDVLlxNrsOfwlI3rfYy1zA==",
+            "version": "5.5.6",
+            "resolved": "https://registry.npmjs.org/json-2-csv/-/json-2-csv-5.5.6.tgz",
+            "integrity": "sha512-N673XbJgHwUq9JreKpk530jSywPF/rEAQ08dV99QQpkluP/4HTwshpoP9hmDz26iSFqu7eNAPgyJfu/77HvPGA==",
             "dependencies": {
                 "deeks": "3.1.0",
                 "doc-path": "4.1.1"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     ],
     "dependencies": {
         "commander": "12.1.0",
-        "json-2-csv": "5.5.5"
+        "json-2-csv": "5.5.6"
     },
     "engines": {
         "node": ">= 18"


### PR DESCRIPTION
Fixes:
* #17 - resolves underlying unhandled `.split` error and remaps `-h` to properly show help text rather than being used for a CLI flag.

Dependencies:
* Updates `json-2-csv` to latest version to pull in a bug fix (https://github.com/mrodrig/json-2-csv/pull/264) and patches a moderate severity vulnerable in a sub-dependency via `npm audit fix`.